### PR TITLE
Fix to triggers when calling @future methods

### DIFF
--- a/src/triggers/caseSwarm.trigger
+++ b/src/triggers/caseSwarm.trigger
@@ -36,7 +36,10 @@ trigger caseSwarm on Case(after insert, after update) {
    }//for
    
     if (caseIds.size() > 1) {
-       swarmHelper.evaluateCaseRulesFuture(caseIds);
+    	// Future methods cannot be called from other future methods or batch processes
+        if(!System.isBatch() && !System.isFuture()){
+        	swarmHelper.evaluateCaseRulesFuture(caseIds);
+		}
     } else {
        swarmHelper.evaluateCaseRules(caseIds);
     }

--- a/src/triggers/leadSwarm.trigger
+++ b/src/triggers/leadSwarm.trigger
@@ -36,7 +36,10 @@ trigger leadSwarm on Lead (after insert, after update) {
     }// for
 
     if (leadIds.size() > 1) {
-        SwarmHelper.evaluateLeadRulesFuture(leadIds);
+    	// Future methods cannot be called from other future methods or batch processes
+        if(!System.isBatch() && !System.isFuture()){
+        	SwarmHelper.evaluateLeadRulesFuture(leadIds);
+        }
     } else {
         SwarmHelper.evaluateLeadRules(leadIds);
     }

--- a/src/triggers/opptySwarm.trigger
+++ b/src/triggers/opptySwarm.trigger
@@ -36,7 +36,10 @@ trigger opptySwarm on Opportunity (after insert, after update) {
     }// for
 
     if (opptyIds.size() > 1) {
-        SwarmHelper.evaluateOpptyRulesFuture(opptyIds);
+    	// Future methods cannot be called from other future methods or batch processes
+        if(!System.isBatch() && !System.isFuture()){
+        	SwarmHelper.evaluateOpptyRulesFuture(opptyIds);
+        }
     } else {
         SwarmHelper.evaluateOpptyRules(opptyIds);
     }


### PR DESCRIPTION
The triggers in CloudSwarm conflict with other apps. For example, our app has a batch job that runs to mass update records. When doing so on a ClourdSwarm object, you get the dreaded "Future methods cannot be called from other future methods" error.

The included fixes will only launch the @future triggers if we are not already in the Future or Batch contexts.

Please test this and get it into the main managed package. This issue causes conflicts with other AppExchange apps and Cloudswarm should fix it to be a good AppExchange citizen.
